### PR TITLE
Add libbambuser.h dependency to podspec

### DIFF
--- a/react-native-bambuser-broadcaster.podspec
+++ b/react-native-bambuser-broadcaster.podspec
@@ -16,4 +16,5 @@ Pod::Spec.new do |s|
   s.source_files  = "ios/*.{h,m}"
 
   s.dependency 'React'
+  s.dependency 'libbambuser-ios'
 end


### PR DESCRIPTION
Fixes #18 and so you don't have to install this dependency manually.